### PR TITLE
keep newlines and replace comments with white space

### DIFF
--- a/json_minify/test_json_minify.py
+++ b/json_minify/test_json_minify.py
@@ -31,11 +31,31 @@ class JsonMinifyTestCase(unittest.TestCase):
                from such a file with the JSON.minify() project hosted
                here on github at http://github.com/getify/JSON.minify
             */''',
+            '''
+                                               \x20
+            {
+                "foo": "bar",                  \x20
+                "bar": [
+                    "baz", "bum"
+                ],
+                                                     \x20
+                                            \x20
+                "something": 10,
+                "else": 20
+            }
+
+                                                                    \x20
+                                                                    \x20
+                                                                    \x20
+              ''',
             '{"foo":"bar","bar":["baz","bum"],"something":10,"else":20}'
         ],
         [
             '''
             {"/*":"*/","//":"",/*"//"*/"/*/"://
+            "//"}''',
+            '''
+            {"/*":"*/","//":"",        "/*/":  
             "//"}''',
             '{"/*":"*/","//":"","/*/":"//"}'
         ],
@@ -53,6 +73,19 @@ class JsonMinifyTestCase(unittest.TestCase):
 
             }
             ''',
+            '''
+             \x20
+                    \x20
+                                 {
+
+            "foo"
+            :
+                "bar/*"           \x20
+                ,    "b\\\"az": \x20
+                             "blah"
+
+            }
+            ''',
             r'{"foo":"bar/*","b\"az":"blah"}'
         ],
         [
@@ -61,15 +94,24 @@ class JsonMinifyTestCase(unittest.TestCase):
             "baz\\\\": /* yay */ "fo\\\\\"*/o"
             }
             ''',
+            r'''
+            {"foo": "ba\"r//", "bar\\": "b\\\"a/*z",
+            "baz\\\\":           "fo\\\\\"*/o"
+            }
+            ''',
             r'{"foo":"ba\"r//","bar\\":"b\\\"a/*z","baz\\\\":"fo\\\\\"*/o"}'  # noqa
         ]
     ]
 
     def template(self, index):
-        in_string, expected = self.tests[index - 1]
+        in_string, expected_whitespace, expected = self.tests[index - 1]
+        self._space_template(in_string, expected_whitespace)
+
         in_dict = json.loads(json_minify(in_string))
+        whitespace_dict = json.loads(json_minify(expected_whitespace))
         expected_dict = json.loads(textwrap.dedent(expected))
         self.assertEqual(in_dict, expected_dict)
+        self.assertEqual(whitespace_dict, expected_dict)
 
     def test_1(self):
         self.template(1)
@@ -82,6 +124,29 @@ class JsonMinifyTestCase(unittest.TestCase):
 
     def test_4(self):
         self.template(4)
+
+    def _space_template(self, in_string, expected):
+        actual = json_minify(in_string, strip_space=False)
+        self.assertEqual(actual, expected)
+
+    def test_space_keeping(self):
+        self._space_template('', '')
+        self._space_template('\n', '\n')
+        self._space_template(' \r\n ', ' \r\n ')
+        self._space_template('\t', '\t')
+
+    def test_space_after_comments(self):
+        self._space_template('//', '  ')
+        self._space_template('// ', '   ')
+        self._space_template('//\n ', '  \n ')
+        self._space_template('//  \n ', '    \n ')
+        self._space_template('/**/', '    ')
+        self._space_template('/**/\n ', '    \n ')
+        self._space_template('/*\n*/\n ', '  \n  \n ')
+
+    def test_single_line_within_multi_line_comment(self):
+        self._space_template('/* \n// \n */\n   ', '   \n   \n   \n   ')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If strip_space is False, keep newlines and replace comments with white space so that the JSON parser reports the correct line and column numbers on parsing errors.

This fixes issue #5 for the python version.