### PR TITLE
Complete rewrite without RegExp

### DIFF
--- a/minify.json.js
+++ b/minify.json.js
@@ -55,6 +55,10 @@
 					if (c == "/") {
 						if (i >= len) {
 							add_chars = 1;
+							if (new_chars == 0) {
+								from = i - add_chars;
+							}
+							new_chars += add_chars;
 							break;
 						}
 						backslash = !backslash && c == "\\"

--- a/minify.json.js
+++ b/minify.json.js
@@ -10,64 +10,85 @@
 
 	global.JSON.minify = function JSON_minify(json) {
 
-		var tokenizer = /"|(\/\*)|(\*\/)|(\/\/)|\n|\r/g,
-			in_string = false,
+		var in_string = false,
 			in_multiline_comment = false,
 			in_singleline_comment = false,
-			tmp, tmp2, new_str = [], ns = 0, from = 0, lc, rc,
-			prevFrom
-		;
+			backslash = false,
+			len = json.length,
+			i = 0,
+			c,
+			new_str = [],
+			from = 0,
+			new_chars = 0,
+			add_chars = 0;
 
-		tokenizer.lastIndex = 0;
-
-		while (tmp = tokenizer.exec(json)) {
-			lc = RegExp.leftContext;
-			rc = RegExp.rightContext;
-			if (!in_multiline_comment && !in_singleline_comment) {
-				tmp2 = lc.substring(from);
-				if (!in_string) {
-					tmp2 = tmp2.replace(/(\n|\r|\s)+/g,"");
+		while (i < len) {
+			backslash = !backslash && c == "\\"
+			c = json[i++];
+			if (in_singleline_comment) {
+				if (c == "\r" || c == "\n") {
+					in_singleline_comment = false;
 				}
-				new_str[ns++] = tmp2;
 			}
-			prevFrom = from;
-			from = tokenizer.lastIndex;
-
-			// found a " character, and we're not currently in
-			// a comment? check for previous `\` escaping immediately
-			// leftward adjacent to this match
-			if (tmp[0] == "\"" && !in_multiline_comment && !in_singleline_comment) {
-				// perform look-behind escaping match, but
-				// limit left-context matching to only go back
-				// to the position of the last token match
-				//
-				// see: https://github.com/getify/JSON.minify/issues/64
-				tmp2 = lc.substring(prevFrom).match(/\\+$/);
-
-				// start of string with ", or unescaped " character found to end string?
-				if (!in_string || !tmp2 || (tmp2[0].length % 2) == 0) {
+			else if (in_multiline_comment) {
+				if (c == "*") {
+					if (i >= len) {
+						break;
+					}
+					c = json[i++];
+					if (c == "/") {
+						in_multiline_comment = false;
+					}
+				}
+			}
+			else {
+				if (c == "\"" && !backslash) {
 					in_string = !in_string;
+					add_chars = 1;
 				}
-				from--; // include " character in next catch
-				rc = json.substring(from);
+				else if (in_string) {
+					if (c != "\n" && c != "\r") {
+						add_chars = 1;
+					}
+				}
+				else {
+					if (c == "/") {
+						if (i >= len) {
+							add_chars = 1;
+							break;
+						}
+						backslash = !backslash && c == "\\"
+						c = json[i++];
+						if (c == "/") {
+							in_singleline_comment = true;
+						}
+						else if (c == "*") {
+							in_multiline_comment = true;
+						}
+						else {
+							add_chars = 2;
+						}
+					}
+					else if (c !== " " && c !== "\t" && c !== "\n" && c !== "\r") {
+						add_chars = 1;
+					}
+				}
 			}
-			else if (tmp[0] == "/*" && !in_string && !in_multiline_comment && !in_singleline_comment) {
-				in_multiline_comment = true;
+			if (add_chars > 0) {
+				if (new_chars == 0) {
+					from = i - add_chars;
+				}
+				new_chars += add_chars;
+				add_chars = 0;
 			}
-			else if (tmp[0] == "*/" && !in_string && in_multiline_comment && !in_singleline_comment) {
-				in_multiline_comment = false;
-			}
-			else if (tmp[0] == "//" && !in_string && !in_multiline_comment && !in_singleline_comment) {
-				in_singleline_comment = true;
-			}
-			else if ((tmp[0] == "\n" || tmp[0] == "\r") && !in_string && !in_multiline_comment && in_singleline_comment) {
-				in_singleline_comment = false;
-			}
-			else if (!in_multiline_comment && !in_singleline_comment && !(/\n|\r|\s/.test(tmp[0]))) {
-				new_str[ns++] = tmp[0];
+			else if (new_chars > 0) {
+				new_str.push(json.substring(from, from + new_chars));
+				new_chars = 0;
 			}
 		}
-		new_str[ns++] = rc;
+		if (new_chars > 0) {
+			new_str.push(json.substring(from, from + new_chars));
+		}
 		return new_str.join("");
 	};
 })(


### PR DESCRIPTION
Somewhat inspired by this: https://gist.github.com/WizKid/1170297, I have completely rewritten the minifier to achieve better performance. It passes the given tests and returns the same result as the upstream for all valid jsons that I have tested, except that it fixes this issue: https://github.com/getify/JSON.minify/issues/71 . Invalid jsons may return different results, e.g. I have seen upstream working with unescaped quoes inside strings, while my code toggles in_comment. Another note: The upstream code does remove newlines from inside strings, is it intended? I think it is wrong, but I did it as well to avoid introducing another difference that should be addressed separately. If it needs to be fixed, the test at line 50 can be simply removed.

Performances:
1) wireguard.txt mentioned here: https://github.com/getify/JSON.minify/pull/52
source length 154741, minified length 154741
upstream time 18 ms = 8502 chars/ms
forked time 6 ms = 25367 chars/ms

2) https://github.com/json-iterator/test-data/blob/master/large-file.json
source length 26141343, minified length 26129992
upstream time 1164 ms = 22454 chars/ms
forked time 562 ms = 46490 chars/ms

3) https://github.com/cytoscape/cytoscape.js/blob/unstable/documentation/demos/cose-layout/data.json
source length 259660, minified length 186042
upstream time 36 ms = 7213 chars/ms
forked time 10 ms = 27048 chars/ms

22 MB/sec is not bad, but if you can do 45, I'd say why not? The code is also probably easier to port to other languages since it does not need a regex implementation, although in other languages there may be more effective ways to build large strings.