### PR TITLE
python: use raw strings in regex containing escapes. Fix SyntaxWarning in python 3.12

### DIFF
--- a/json_minify/__init__.py
+++ b/json_minify/__init__.py
@@ -17,7 +17,7 @@ import re
 
 
 def json_minify(string, strip_space=True):
-    tokenizer = re.compile('"|(/\*)|(\*/)|(//)|\n|\r')
+    tokenizer = re.compile(r'"|(/\*)|(\*/)|(//)|\n|\r')
     end_slashes_re = re.compile(r'(\\)*$')
 
     in_string = False


### PR DESCRIPTION
Before this change:

```
<BASE>/json_minify/__init__.py:20: SyntaxWarning: invalid escape sequence '\*'
  tokenizer = re.compile('"|(/\*)|(\*/)|(//)|\n|\r')
```
